### PR TITLE
removing type attribute from sensor elements

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/SensorElementList.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/SensorElementList.java
@@ -47,8 +47,6 @@ import org.eclipse.persistence.oxm.annotations.XmlPath;
 @XmlType(propOrder = {"sensorMetadata", "sensorReport", "extension", "anyElements"})
 public class SensorElementList implements Serializable {
 
-  @XmlTransient private String type = "epcis:SensorElement";
-
   @JsonIgnore @XmlTransient private Map<String, Object> innerUserExtensions;
 
   private SensorMetadata sensorMetadata;


### PR DESCRIPTION
Currently during the creation of EPCIS JSON events with sensorElements `"type": "epcis:SensorElement",` is being added to all elements due to this the events are not adhering to JSON Schema.

This is occurring because of the presence of the field `private String type = "epcis:SensorElement";`, hence removing this field to match the JSON schema.

Kindly request you to please review and merge this pull request.