### PR TITLE
adding certificationInfo to all epcis model classes and generated events

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/AggregationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/AggregationEvent.java
@@ -38,6 +38,7 @@ import lombok.*;
       "eventTimeZoneOffset",
       "eventID",
       "errorDeclaration",
+      "certificationInfo",
       "baseExtension",
       "parentID",
       "childEPCs",
@@ -72,6 +73,7 @@ import lombok.*;
   "recordTime",
   "eventTimeZoneOffset",
   "eventID",
+  "certificationInfo",
   "errorDeclaration",
   "parentID",
   "childEPCs",
@@ -126,6 +128,7 @@ public class AggregationEvent extends EPCISEvent implements XmlSupportExtension 
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
+      String certificationInfo,
       List<SourceList> sourceList,
       List<DestinationList> destinationList,
       List<SensorElementList> sensorElementList,
@@ -156,6 +159,7 @@ public class AggregationEvent extends EPCISEvent implements XmlSupportExtension 
         userExtensions,
         innerUserExtensions,
         contextInfo,
+        certificationInfo,
         null);
     this.action = action;
     this.childQuantityList = childQuantityList;

--- a/epcis/src/main/java/io/openepcis/model/epcis/AssociationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/AssociationEvent.java
@@ -34,6 +34,7 @@ import lombok.*;
       "recordTime",
       "eventID",
       "errorDeclaration",
+      "certificationInfo",
       "baseExtension",
       "parentID",
       "childEPCs",
@@ -71,6 +72,7 @@ import lombok.*;
   "recordTime",
   "eventID",
   "errorDeclaration",
+  "certificationInfo",
   "parentID",
   "childEPCs",
   "childQuantityList",
@@ -84,7 +86,7 @@ import lombok.*;
   "destinationList",
   "sensorElementList",
   "persistentDisposition",
-  "anyElements"
+  "userExtensions"
 })
 public class AssociationEvent extends EPCISEvent implements XmlSupportExtension {
 
@@ -124,6 +126,7 @@ public class AssociationEvent extends EPCISEvent implements XmlSupportExtension 
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
+      String certificationInfo,
       List<SourceList> sourceList,
       List<DestinationList> destinationList,
       List<SensorElementList> sensorElementList,
@@ -154,6 +157,7 @@ public class AssociationEvent extends EPCISEvent implements XmlSupportExtension 
         userExtensions,
         innerUserExtensions,
         contextInfo,
+        certificationInfo,
         null);
     this.action = action;
     this.childQuantityList = childQuantityList;

--- a/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
@@ -111,6 +111,8 @@ public class EPCISEvent implements Serializable {
   @XmlTransient
   private List<Object> contextInfo;
 
+  private String certificationInfo;
+
   @JsonIgnore @XmlTransient private String expandedJSONLDString;
 
   public EPCISEvent(
@@ -134,6 +136,7 @@ public class EPCISEvent implements Serializable {
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
+      String certificationInfo,
       String expandedJSONLDString) {
     this.type = type;
     this.eventID = eventID;
@@ -155,6 +158,7 @@ public class EPCISEvent implements Serializable {
     this.userExtensions = userExtensions;
     this.innerUserExtensions = innerUserExtensions;
     this.contextInfo = contextInfo;
+    this.certificationInfo = certificationInfo;
     this.expandedJSONLDString = expandedJSONLDString;
   }
 

--- a/epcis/src/main/java/io/openepcis/model/epcis/ObjectEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/ObjectEvent.java
@@ -39,6 +39,7 @@ import lombok.*;
       "eventTimeZoneOffset",
       "eventID",
       "errorDeclaration",
+      "certificationInfo",
       "baseExtension",
       "epcList",
       "action",
@@ -71,6 +72,7 @@ import lombok.*;
   "recordTime",
   "eventTimeZoneOffset",
   "eventID",
+  "certificationInfo",
   "errorDeclaration",
   "epcList",
   "action",
@@ -136,6 +138,7 @@ public class ObjectEvent extends EPCISEvent implements XmlSupportExtension {
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
+      String certificationInfo,
       List<SourceList> sourceList,
       List<DestinationList> destinationList,
       List<SensorElementList> sensorElementList,
@@ -166,6 +169,7 @@ public class ObjectEvent extends EPCISEvent implements XmlSupportExtension {
         userExtensions,
         innerUserExtensions,
         contextInfo,
+        certificationInfo,
         null);
     this.action = action;
     this.quantityList = quantityList;

--- a/epcis/src/main/java/io/openepcis/model/epcis/TransactionEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/TransactionEvent.java
@@ -37,6 +37,7 @@ import lombok.*;
       "eventTimeZoneOffset",
       "eventID",
       "errorDeclaration",
+      "certificationInfo",
       "baseExtension",
       "bizTransactionList",
       "parentID",
@@ -71,6 +72,7 @@ import lombok.*;
   "recordTime",
   "eventTimeZoneOffset",
   "eventID",
+  "certificationInfo",
   "errorDeclaration",
   "bizTransactionList",
   "parentID",
@@ -125,6 +127,7 @@ public class TransactionEvent extends EPCISEvent implements XmlSupportExtension 
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
+      String certificationInfo,
       List<SourceList> sourceList,
       List<DestinationList> destinationList,
       List<SensorElementList> sensorElementList,
@@ -155,6 +158,7 @@ public class TransactionEvent extends EPCISEvent implements XmlSupportExtension 
         userExtensions,
         innerUserExtensions,
         contextInfo,
+        certificationInfo,
         null);
     this.action = action;
     this.quantityList = quantityList;

--- a/epcis/src/main/java/io/openepcis/model/epcis/TransformationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/TransformationEvent.java
@@ -37,6 +37,7 @@ import lombok.*;
       "eventTimeZoneOffset",
       "eventID",
       "errorDeclaration",
+      "certificationInfo",
       "baseExtension",
       "inputEPCList",
       "inputQuantityList",
@@ -78,6 +79,7 @@ import lombok.*;
   "recordTime",
   "eventTimeZoneOffset",
   "eventID",
+  "certificationInfo",
   "errorDeclaration",
   "inputEPCList",
   "inputQuantityList",
@@ -150,6 +152,7 @@ public class TransformationEvent extends EPCISEvent implements XmlSupportExtensi
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
+      String certificationInfo,
       List<SourceList> sourceList,
       List<DestinationList> destinationList,
       List<SensorElementList> sensorElementList,
@@ -182,6 +185,7 @@ public class TransformationEvent extends EPCISEvent implements XmlSupportExtensi
         userExtensions,
         innerUserExtensions,
         contextInfo,
+        certificationInfo,
         null);
     this.inputEPCList = inputEPCList;
     this.outputEPCList = outputEPCList;


### PR DESCRIPTION
The field certificationInfo was missing in our EPCIS classes so it has been added to `EPCISEvent.class` and same has been updated in other event classes.

As this was needed to fix the issues created by Ralph on Test Data Generator, I kindly request you to approve the request and merge.