### PR TITLE
initialize the userExtensions map to avoid null exception.

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
@@ -102,7 +102,7 @@ public class EPCISEvent implements Serializable {
 
   @XmlTransient private String captureID;
 
-  @XmlTransient private Map<String, Object> userExtensions;
+  @XmlTransient private Map<String, Object> userExtensions = new HashMap<>();
 
   @JsonIgnore @XmlTransient private Map<String, Object> innerUserExtensions;
 


### PR DESCRIPTION
Currently during the conversion of XML to JSON some documents are running across null exception. This is due to not initialising the userExtension variable in EPCISEvent class. This PR will fix that issue. Kindly request you to review the PR and approve the same.

This will fix the issue:
https://jira.company-group.com/browse/OEPCIS-513
https://jira.company-group.com/browse/OEPCIS-514