### PR TITLE
creating the single instance of namespace resolver instead of multipl…

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/modifier/CommonExtensionModifier.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/modifier/CommonExtensionModifier.java
@@ -9,6 +9,8 @@ import org.w3c.dom.NodeList;
 public class CommonExtensionModifier {
 
   private static final String EMPTY_STRING_CHECKER = "[\\n\\t ]";
+  private static final DefaultJsonSchemaNamespaceURIResolver namespaceResolver =
+      DefaultJsonSchemaNamespaceURIResolver.getInstance();
 
   public static Map<String, Object> extensionPopulate(
       Map<String, Object> extensionsPop, String nodeName, Object nodeContent) {
@@ -35,14 +37,14 @@ public class CommonExtensionModifier {
     if (value == null) {
       return Collections.emptyMap();
     }
+
     Map<String, Object> extensions = new HashMap<>();
 
     for (Object obj : value) {
       final Element element = (Element) obj;
       final NodeList children = element.getChildNodes();
 
-      DefaultJsonSchemaNamespaceURIResolver.getInstance()
-          .populateEventNamespaces(element.getNamespaceURI(), element.getPrefix());
+      namespaceResolver.populateEventNamespaces(element.getNamespaceURI(), element.getPrefix());
 
       // If simple type then directly add text to MAP
       if (children.getLength() == 1
@@ -60,8 +62,8 @@ public class CommonExtensionModifier {
             final Element innerElement = (Element) n;
             final NodeList innerChildren = innerElement.getChildNodes();
 
-            DefaultJsonSchemaNamespaceURIResolver.getInstance()
-                .populateEventNamespaces(innerElement.getNamespaceURI(), innerElement.getPrefix());
+            namespaceResolver.populateEventNamespaces(
+                innerElement.getNamespaceURI(), innerElement.getPrefix());
 
             if (innerChildren.getLength() == 1
                 && !innerElement.getTextContent().replaceAll(EMPTY_STRING_CHECKER, "").equals("")) {

--- a/epcis/src/main/java/io/openepcis/model/epcis/modifier/CustomContextDeserialize.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/modifier/CustomContextDeserialize.java
@@ -28,7 +28,7 @@ import java.util.Map;
 
 public class CustomContextDeserialize extends JsonDeserializer<List<Object>> {
 
-  private final DefaultJsonSchemaNamespaceURIResolver resolver =
+  private final DefaultJsonSchemaNamespaceURIResolver namespaceResolver =
       DefaultJsonSchemaNamespaceURIResolver.getInstance();
   private final ObjectMapper objectMapper = new ObjectMapper();
 
@@ -45,14 +45,15 @@ public class CustomContextDeserialize extends JsonDeserializer<List<Object>> {
           item -> {
             if (item instanceof Map) {
               final Map<String, String> namespaceLoc = (Map<String, String>) item;
-              namespaceLoc.forEach((key, value) -> resolver.populateEventNamespaces(value, key));
+              namespaceLoc.forEach(
+                  (key, value) -> namespaceResolver.populateEventNamespaces(value, key));
             }
           });
     } else {
       // If context is not populated then during the XML unmarshalling populate based on the values
       // present in DefaultJsonSchemaNamespaceURIResolver
-      if (!resolver.getEventNamespaces().isEmpty()) {
-        return new ArrayList<>(resolver.getEventNamespaces().values());
+      if (!namespaceResolver.getEventNamespaces().isEmpty()) {
+        return new ArrayList<>(namespaceResolver.getEventNamespaces().values());
       }
     }
 

--- a/epcis/src/main/java/io/openepcis/model/epcis/modifier/CustomContextSerializer.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/modifier/CustomContextSerializer.java
@@ -10,6 +10,9 @@ import java.util.Map;
 
 public class CustomContextSerializer extends JsonSerializer<List<Object>> {
 
+  private final DefaultJsonSchemaNamespaceURIResolver namespaceResolver =
+      DefaultJsonSchemaNamespaceURIResolver.getInstance();
+
   @Override
   public void serialize(
       final List<Object> contextValue,
@@ -17,12 +20,10 @@ public class CustomContextSerializer extends JsonSerializer<List<Object>> {
       final SerializerProvider serializers)
       throws IOException {
     try {
-      final DefaultJsonSchemaNamespaceURIResolver resolver =
-          DefaultJsonSchemaNamespaceURIResolver.getInstance();
-      resolver.modifyEventNamespaces();
+      namespaceResolver.modifyEventNamespaces();
       jsonGenerator.writeStartArray();
 
-      final Map<String, String> modifiedNamespaces = resolver.getModifiedNamespaces();
+      final Map<String, String> modifiedNamespaces = namespaceResolver.getModifiedNamespaces();
 
       for (final Map.Entry<String, String> entry : modifiedNamespaces.entrySet()) {
         jsonGenerator.writeStartObject();
@@ -31,8 +32,8 @@ public class CustomContextSerializer extends JsonSerializer<List<Object>> {
       }
 
       jsonGenerator.writeEndArray();
-      resolver.resetEventNamespaces();
-      resolver.resetModifiedNamespaces();
+      namespaceResolver.resetEventNamespaces();
+      namespaceResolver.resetModifiedNamespaces();
     } catch (IOException e) {
       throw new IOException(
           "Exception occurred during the writing of context elements: " + e.getMessage(), e);

--- a/epcis/src/main/java/io/openepcis/model/epcis/modifier/CustomExtensionAdapter.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/modifier/CustomExtensionAdapter.java
@@ -26,6 +26,9 @@ import lombok.Setter;
 
 public class CustomExtensionAdapter extends XmlAdapter<MapWrapper, Map<String, Object>> {
 
+  private final DefaultJsonSchemaNamespaceURIResolver namespaceResolver =
+      DefaultJsonSchemaNamespaceURIResolver.getInstance();
+
   @Override
   public MapWrapper marshal(final Map<String, Object> extensions) {
     if (extensions == null) {
@@ -46,8 +49,7 @@ public class CustomExtensionAdapter extends XmlAdapter<MapWrapper, Map<String, O
       String namespaceURI = null;
 
       if (prefix != null) {
-        Optional<String> namespace =
-            DefaultJsonSchemaNamespaceURIResolver.getInstance().findNamespaceByPrefix(prefix);
+        Optional<String> namespace = namespaceResolver.findNamespaceByPrefix(prefix);
         if (namespace.isPresent()) {
           namespaceURI = namespace.get();
         }


### PR DESCRIPTION
@sboeckelmann As requested add the changes for creating the single instance of the DefaultJsonSchemaNamespaceURIResolver rather than multiple getInstance() per class. Kindly request you to review the code and approve the PR.