### PR TITLE
Refactor and Straighten up Subscription Endpoints

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/dto/QuerySubscriptionEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/dto/QuerySubscriptionEvent.java
@@ -36,7 +36,8 @@ public class QuerySubscriptionEvent {
   private URI callbackUrl;
   private String secret;
   private OffsetDateTime initialRecordTime;
-  private boolean reportIfEmpty;
+  private Boolean reportIfEmpty;
+  private Boolean stream;
   private Schedule schedule;
   private OffsetDateTime createdAt;
 }

--- a/epcis/src/main/java/io/openepcis/model/epcis/NamedQuerySubscription.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/NamedQuerySubscription.java
@@ -37,7 +37,8 @@ public class NamedQuerySubscription {
   private String secret;
   private OffsetDateTime minRecordTime;
   private OffsetDateTime initialRecordTime;
-  private boolean reportIfEmpty;
+  private Boolean reportIfEmpty;
+  private Boolean stream;
   private Schedule schedule;
   private boolean deleted = false;
   private OffsetDateTime createdAt;

--- a/epcis/src/main/java/io/openepcis/model/epcis/constants/CommonConstants.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/constants/CommonConstants.java
@@ -72,4 +72,5 @@ public class CommonConstants {
   public static final String SUB = "sub";
   public static final String CAPTURED_BY = "capturedBy";
   public static final String ROLES_ALLOWED = "rolesAllowed";
+  public static final String SUBSCRIPTION_INTERVAL_PATH = "app.subscription.streaming-interval";
 }

--- a/epcis/src/main/java/io/openepcis/model/epcis/constants/QueryParameterConstants.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/constants/QueryParameterConstants.java
@@ -38,6 +38,7 @@ public class QueryParameterConstants {
   public static final String ORDER_DIRECTION = "orderDirection";
   public static final String PARAMETERS = "Parameters";
   public static final String CONTEXT = "@context";
+  public static final String STREAM = "stream";
 
   private QueryParameterConstants() {
     // Bunch of constants so there should be a no need to create object for this class

--- a/epcis/src/main/java/io/openepcis/model/epcis/exception/ExceptionMessages.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/exception/ExceptionMessages.java
@@ -179,6 +179,8 @@ public class ExceptionMessages {
   public static final String
       NON_ZERO_CONCENTRATION_VALUE_IS_INCOMPATIBLE_WITH_BOOLEANVALUE_FALSE_IN_SENSOR_REPORT =
           "A non-zero concentration value is incompatible with booleanValue=false in sensor report";
+  public static final String SUBSCRIPTION_STREAM_AND_SCHEDULE_ARE_MUTUALLY_EXCLUSIVE =
+      "Query subscription stream and schedule are mutually exclusive";
 
   private ExceptionMessages() {
     // Bunch of constants so there should be no need to create object of this class


### PR DESCRIPTION
The following commit adds the `stream` field in the Query-Subscription models in order to support streaming subscriptions.