### PR TITLE
Add DocumentType in common constants

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/constants/CommonConstants.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/constants/CommonConstants.java
@@ -73,4 +73,5 @@ public class CommonConstants {
   public static final String CAPTURED_BY = "capturedBy";
   public static final String ROLES_ALLOWED = "rolesAllowed";
   public static final String SUBSCRIPTION_INTERVAL_PATH = "app.subscription.streaming-interval";
+  public static final String DOCUMENT_TYPE = "DocumentType";
 }


### PR DESCRIPTION
Following PR adds a DocumentType constant in common constants. Request you to review and approve the PR