### PR TITLE
Cleanup CommonConstants

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/constants/CommonConstants.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/constants/CommonConstants.java
@@ -65,13 +65,5 @@ public class CommonConstants {
   public static final String GS1_EPC_FORMAT = "GS1-EPC-Format";
   public static final String GS1_SIGNATURE = "GS1-Signature";
   public static final String ISO8601_TIMESTAMP_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
-  public static final String EVENT_ACCESS = "event-access";
-  public static final String QUERY_ROLE = "query";
-  public static final String ID = "ID";
-  public static final String USERINFO = "userinfo";
-  public static final String SUB = "sub";
-  public static final String CAPTURED_BY = "capturedBy";
-  public static final String ROLES_ALLOWED = "rolesAllowed";
-  public static final String SUBSCRIPTION_INTERVAL_PATH = "app.subscription.streaming-interval";
   public static final String DOCUMENT_TYPE = "DocumentType";
 }


### PR DESCRIPTION
Removed the following from `CommonConstants` : 
```java

  public static final String EVENT_ACCESS = "event-access";
  public static final String QUERY_ROLE = "query";
  public static final String ID = "ID";
  public static final String USERINFO = "userinfo";
  public static final String SUB = "sub";
  public static final String CAPTURED_BY = "capturedBy";
  public static final String ROLES_ALLOWED = "rolesAllowed";
  public static final String SUBSCRIPTION_INTERVAL_PATH = "app.subscription.streaming-interval";
```
