### PR TITLE
OEPCIS-698: removing empty object and empty array from context during…

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
@@ -60,7 +60,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class EPCISEvent implements Serializable, OpenEPCISSupport {
 
-  @XmlTransient private String type;
+  @XmlTransient @JsonIgnore private String type;
 
   private String eventID;
 

--- a/epcis/src/main/java/io/openepcis/model/epcis/EPCISQueryDocument.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/EPCISQueryDocument.java
@@ -28,10 +28,7 @@ import io.openepcis.model.epcis.modifier.OffsetDateTimeSerializer;
 import jakarta.xml.bind.annotation.*;
 import jakarta.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -99,14 +96,25 @@ public class EPCISQueryDocument {
     final Map<String, Object> contextInfoMap =
         epcisEvents.stream()
             .map(this::convertContextInfoToMap)
+            .filter(map -> !map.isEmpty())
             .flatMap(map -> map.entrySet().stream())
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a));
-    contextInfoList.add(contextInfoMap);
+
+    //Avoid adding the empty map into the context
+    if(!contextInfoMap.isEmpty()){
+      contextInfoList.add(contextInfoMap);
+    }
+
     epcisEvents.forEach(epcisEvent -> epcisEvent.setContextInfo(null));
     return contextInfoList;
   }
 
   private HashMap<String, Object> convertContextInfoToMap(EPCISEvent epcisEvent) {
+    //If context is null or empty then return the empty HashMap to avoid  exception.
+    if(context == null || context.isEmpty()){
+      return new HashMap<>();
+    }
+
     return epcisEvent.getContextInfo().stream()
         .map(m -> new ObjectMapper().convertValue(m, HashMap.class))
         .toList()


### PR DESCRIPTION
Hi @sboeckelmann 

This PR contains the fixes associated with the context-related issues during the capture or query of an EPCIS document or bare event.

Previously `/events` was adding the empty object into the context:
```
"@context": [
        "https://ref.gs1.org/standards/epcis/2.0.0/epcis-context.jsonld",
        {}
    ],
```

Also during the capture of the bare event the returned response contained the empty context array, if you observe the `type` appears twice in the returned response:
```
{
    "type": "ObjectEvent",
    "@context": [],
    "type": "ObjectEvent",
```

This PR along with another PR on GitLab openepcis-core, should fix these issues: https://code.company-group.com//openepcis/openepcis-core/-/merge_requests/24


Kindly request you to review both the PR and approve.
