### PR TITLE
adding support to missing ilmd issue during format-conversion.

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/ObjectEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/ObjectEvent.java
@@ -148,6 +148,7 @@ public class ObjectEvent extends EPCISEvent implements XmlSupportExtension {
       List<String> epcList,
       List<BizTransactionList> bizTransactionList,
       Ilmd ilmd,
+      Map<String, Object> ilmdXml,
       OpenEPCISExtension openEPCISExtension) {
     super(
         type,
@@ -176,6 +177,7 @@ public class ObjectEvent extends EPCISEvent implements XmlSupportExtension {
     this.epcList = epcList;
     this.ilmd = ilmd;
     this.bizTransactionList = bizTransactionList;
+    this.ilmdXml = ilmdXml;
     if (ilmd != null) {
       this.ilmdXml = ilmd.getUserExtensions();
     }

--- a/epcis/src/main/java/io/openepcis/model/epcis/TransformationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/TransformationEvent.java
@@ -166,6 +166,7 @@ public class TransformationEvent extends EPCISEvent implements XmlSupportExtensi
       List<QuantityList> inputQuantityList,
       List<QuantityList> outputQuantityList,
       String transformationID,
+      Map<String, Object> ilmdXml,
       Ilmd ilmd,
       OpenEPCISExtension openEPCISExtension) {
     super(
@@ -196,6 +197,7 @@ public class TransformationEvent extends EPCISEvent implements XmlSupportExtensi
     this.outputQuantityList = outputQuantityList;
     this.transformationID = transformationID;
     this.ilmd = ilmd;
+    this.ilmdXml = ilmdXml;
     if (ilmd != null) {
       this.ilmdXml = ilmd.getUserExtensions();
     }


### PR DESCRIPTION
@sboeckelmann 

We have fixed the issue associated with ILMD elements during the conversion of the XML documents from 1.2 to other formats or versions.

This PR is associated with another PR created in our GitLab project openepcis-core project. Kindly request you to review and approve both PRs.