### PR TITLE
GEN-91:detect the default namespaces during the json deserialization …

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/BizLocation.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/BizLocation.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openepcis.model.epcis.modifier.CustomExtensionAdapter;
+import io.openepcis.model.epcis.modifier.DefaultNamespaceDeserializer;
 import io.openepcis.model.epcis.modifier.ExtensionsModifier;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
@@ -66,6 +67,9 @@ public class BizLocation implements Serializable {
   @JsonAnySetter
   public void setUserExtensions(String key, Object value) {
     userExtensions.put(key, value);
+
+    //Detect default EPCIS namespaces (gs1, cbvmda, etc.) after json deserialization, if present add namespacesURI that are later used for XML marshalling
+    DefaultNamespaceDeserializer.getInstance().processExtensions(userExtensions);
   }
 
   @JsonAnyGetter

--- a/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
@@ -179,11 +179,12 @@ public class EPCISEvent implements Serializable, OpenEPCISSupport {
   private List<Object> anyElements;
 
   @JsonAnySetter
+  @JsonDeserialize(using = DefaultNamespaceDeserializer.class)
   public void setUserExtensions(String key, Object value) {
-    if (userExtensions == null) {
-      userExtensions = new HashMap<>();
-    }
     userExtensions.put(key, value);
+
+    //Detect default EPCIS namespaces (gs1, cbvmda, etc.) after json deserialization, if present add namespacesURI that are later used for XML marshalling
+    DefaultNamespaceDeserializer.getInstance().processExtensions(userExtensions);
   }
 
   public void beforeMarshal(Marshaller m) throws ParserConfigurationException {

--- a/epcis/src/main/java/io/openepcis/model/epcis/ErrorDeclaration.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/ErrorDeclaration.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openepcis.model.epcis.modifier.CustomExtensionAdapter;
+import io.openepcis.model.epcis.modifier.DefaultNamespaceDeserializer;
 import io.openepcis.model.epcis.modifier.ExtensionsModifier;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
@@ -75,6 +76,9 @@ public class ErrorDeclaration implements Serializable {
   @JsonAnySetter
   public void setUserExtensions(String key, Object value) {
     userExtensions.put(key, value);
+
+    //Detect default EPCIS namespaces (gs1, cbvmda, etc.), if present add namespacesURI that are later used for XML marshalling
+    DefaultNamespaceDeserializer.getInstance().processExtensions(userExtensions);
   }
 
   @JsonAnyGetter

--- a/epcis/src/main/java/io/openepcis/model/epcis/ObjectEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/ObjectEvent.java
@@ -16,10 +16,12 @@
 package io.openepcis.model.epcis;
 
 import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openepcis.epc.translator.util.ConverterUtil;
 import io.openepcis.model.epcis.extension.OpenEPCISExtension;
 import io.openepcis.model.epcis.modifier.CustomExtensionAdapter;
+import io.openepcis.model.epcis.modifier.DefaultNamespaceDeserializer;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
 import jakarta.xml.bind.annotation.*;
@@ -119,6 +121,7 @@ public class ObjectEvent extends EPCISEvent implements XmlSupportExtension {
   // To avoid issues conflicting Ilmd type, this variable has been created. This will also avoid
   // making changes to CustomExtensionAdapter class.
   @XmlJavaTypeAdapter(CustomExtensionAdapter.class)
+  @JsonDeserialize(using = DefaultNamespaceDeserializer.class)
   @JsonSerialize(using = CustomExtensionsSerializer.class)
   @UserExtensions(extension = "ilmd")
   @JsonProperty("ilmd")

--- a/epcis/src/main/java/io/openepcis/model/epcis/ReadPoint.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/ReadPoint.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openepcis.model.epcis.modifier.CustomExtensionAdapter;
+import io.openepcis.model.epcis.modifier.DefaultNamespaceDeserializer;
 import io.openepcis.model.epcis.modifier.ExtensionsModifier;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
@@ -67,6 +68,9 @@ public class ReadPoint implements Serializable {
   @JsonAnySetter
   public void setUserExtensions(String key, Object value) {
     userExtensions.put(key, value);
+
+    //Detect default EPCIS namespaces (gs1, cbvmda, etc.) after json deserialization, if present add namespacesURI that are later used for XML marshalling
+    DefaultNamespaceDeserializer.getInstance().processExtensions(userExtensions);
   }
 
   @JsonAnyGetter

--- a/epcis/src/main/java/io/openepcis/model/epcis/SensorElementList.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/SensorElementList.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openepcis.model.epcis.modifier.CustomExtensionAdapter;
+import io.openepcis.model.epcis.modifier.DefaultNamespaceDeserializer;
 import io.openepcis.model.epcis.modifier.ExtensionsModifier;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
@@ -68,6 +69,9 @@ public class SensorElementList implements Serializable {
   @JsonAnySetter
   public void setUserExtensions(String key, Object value) {
     userExtensions.put(key, value);
+
+    //Detect default EPCIS namespaces (gs1, cbvmda, etc.) after json deserialization, if present add namespacesURI that are later used for XML marshalling
+    DefaultNamespaceDeserializer.getInstance().processExtensions(userExtensions);
   }
 
   @JsonAnyGetter

--- a/epcis/src/main/java/io/openepcis/model/epcis/TransformationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/TransformationEvent.java
@@ -16,10 +16,12 @@
 package io.openepcis.model.epcis;
 
 import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.openepcis.epc.translator.util.ConverterUtil;
 import io.openepcis.model.epcis.extension.OpenEPCISExtension;
 import io.openepcis.model.epcis.modifier.CustomExtensionAdapter;
+import io.openepcis.model.epcis.modifier.DefaultNamespaceDeserializer;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;
 import jakarta.xml.bind.annotation.*;
@@ -134,6 +136,7 @@ public class TransformationEvent extends EPCISEvent implements XmlSupportExtensi
   // To avoid issues conflicting Ilmd type, this variable has been created. This will also avoid
   // making changes to CustomExtensionAdapter class.
   @XmlJavaTypeAdapter(CustomExtensionAdapter.class)
+  @JsonDeserialize(using = DefaultNamespaceDeserializer.class)
   @JsonSerialize(using = CustomExtensionsSerializer.class)
   @UserExtensions(extension = "ilmd")
   @JsonProperty("ilmd")

--- a/epcis/src/main/java/io/openepcis/model/epcis/modifier/DefaultNamespaceDeserializer.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/modifier/DefaultNamespaceDeserializer.java
@@ -1,0 +1,85 @@
+package io.openepcis.model.epcis.modifier;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openepcis.model.epcis.util.DefaultJsonSchemaNamespaceURIResolver;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.openepcis.constants.EPCIS.EPCIS_DEFAULT_NAMESPACES;
+
+/**
+ * This class will detect any default EPCIS namespaces in userExtension, ilmd, or errorExtension. If the namespaces aren't detected and included in the DefaultJsonSchemaNamespaceURIResolver EventNamespaces then during the marshalling it produces
+ * error
+ */
+@Slf4j
+@NoArgsConstructor
+public class DefaultNamespaceDeserializer extends JsonDeserializer<Map<String, Object>> {
+
+    private static DefaultNamespaceDeserializer instance;
+    private final DefaultJsonSchemaNamespaceURIResolver namespaceResolver = DefaultJsonSchemaNamespaceURIResolver.getContext();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public Map<String, Object> deserialize(final JsonParser jsonParser, final DeserializationContext context) throws IOException {
+        final Map<String, Object> extensionsNode = objectMapper.readValue(jsonParser, new TypeReference<>() {});
+        System.out.println(extensionsNode);
+        processExtensions(extensionsNode);
+        return extensionsNode;
+    }
+
+
+    public static synchronized DefaultNamespaceDeserializer getInstance() {
+        if (instance == null) {
+            instance = new DefaultNamespaceDeserializer();
+        }
+        return instance;
+    }
+
+    /**
+     * This method will detect if the userExtensions, ILMD or errorExtensions contain any default namespace related prefixes. If so then include the corresponding namespace in the namespaceResolver eventNamespaces for the XML Marshalling
+     *
+     * @param extensionsNode Map of all the userExtension for which default namespace needs to be detected ex: {cbvmda:lotNumber=1234}
+     */
+    public void processExtensions(final Map<String, Object> extensionsNode) {
+        extensionsNode.forEach((key, value) -> {
+            if (value instanceof Map) {
+                findNamespace(key);
+                processExtensions((Map<String, Object>) value);
+            } else if (value instanceof List<?>) {
+                ((List<?>) value).forEach(item -> {
+                    if (item instanceof Map) {
+                        findNamespace(key);
+                        processExtensions((Map<String, Object>) item);
+                    } else if (item instanceof String || item instanceof Number) {
+                        findNamespace(key);
+                    }
+                });
+            } else if (value instanceof String) {
+                findNamespace(key);
+            }
+        });
+    }
+
+    /**
+     * Based on the key present for the extension get the prefix and get corresponding namespaceURI and if not present already then populate in namespaceResolver
+     *
+     * @param key key of the userExtension gs1:lotNumber, etc.
+     */
+    private void findNamespace(final String key) {
+        final String prefix = key != null ? key.substring(0, key.indexOf(":")) : null;
+        final Optional<String> namespaceOpt = EPCIS_DEFAULT_NAMESPACES.entrySet().stream()
+                .filter(entry -> entry.getKey().equals(prefix))
+                .map(entry -> (String) entry.getValue())
+                .findFirst();
+        namespaceOpt.ifPresent(entry -> namespaceResolver.populateEventNamespaces(namespaceOpt.get(), prefix));
+    }
+}

--- a/epcis/src/main/java/io/openepcis/model/epcis/modifier/DefaultNamespaceDeserializer.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/modifier/DefaultNamespaceDeserializer.java
@@ -31,7 +31,6 @@ public class DefaultNamespaceDeserializer extends JsonDeserializer<Map<String, O
     @Override
     public Map<String, Object> deserialize(final JsonParser jsonParser, final DeserializationContext context) throws IOException {
         final Map<String, Object> extensionsNode = objectMapper.readValue(jsonParser, new TypeReference<>() {});
-        System.out.println(extensionsNode);
         processExtensions(extensionsNode);
         return extensionsNode;
     }


### PR DESCRIPTION
### Background:

When the EPCIS JSON document includes extensions or ILMD based on the default context, such as `"cbvmda": "urn:epcglobal:cbv:mda:"` or `"gs1": "https://gs1.org/voc/"`, these context URLs are not included within the JSON document's `@context`. During the JSON-to-XML conversion, these contexts cannot be identified and incorporated as namespaces. 

The absence of these namespaces leads to failures in document or event conversion from JSON to XML due to missing namespaces. Providing all namespaces directly to the `marshaller` results in their inclusion in all documents or events, regardless of whether they contain extensions/ilmd based on the default context.

To address this issue, a class is required that can determine the presence of default context-based extensions or ILMD. If such extensions are found, the default contexts should be added to the `DefaultJsonSchemaNamespaceURIResolver`, enabling the `marshaller` to incorporate these namespaces into the generated XML. This approach prevents the unnecessary addition of namespaces to the XML and prevents exceptions related to missing namespaces during JSON-to-XML conversion for documents containing default context-based extensions.


@sboeckelmann kindly request you to review the changes and approve the PR.