### PR TITLE
Convert the certificationInfo field from string to object 

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/AggregationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/AggregationEvent.java
@@ -127,7 +127,7 @@ public class AggregationEvent extends EPCISEvent implements XmlSupportExtension 
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
-      String certificationInfo,
+      Map<String, Object> certificationInfo,
       List<SourceList> sourceList,
       List<DestinationList> destinationList,
       List<SensorElementList> sensorElementList,

--- a/epcis/src/main/java/io/openepcis/model/epcis/AssociationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/AssociationEvent.java
@@ -125,7 +125,7 @@ public class AssociationEvent extends EPCISEvent implements XmlSupportExtension 
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
-      String certificationInfo,
+      Map<String, Object> certificationInfo,
       List<SourceList> sourceList,
       List<DestinationList> destinationList,
       List<SensorElementList> sensorElementList,

--- a/epcis/src/main/java/io/openepcis/model/epcis/CustomExtensionsSerializer.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/CustomExtensionsSerializer.java
@@ -55,7 +55,7 @@ public class CustomExtensionsSerializer extends JsonSerializer<Map<String, Objec
       throws IOException {
     if (this.context.equals("userExtensions")) {
       recursiveSerializer(value, gen);
-    } else if (this.context.equals("ilmd") || this.context.equals("extension")) {
+    } else if (this.context.equals("ilmd") || this.context.equals("extension") || this.context.equals("certificationInfo")) {
       gen.writeStartObject();
       recursiveSerializer(value, gen);
       gen.writeEndObject();

--- a/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
@@ -107,7 +107,11 @@ public class EPCISEvent implements Serializable, OpenEPCISSupport {
   @XmlTransient
   private List<Object> contextInfo;
 
-  private String certificationInfo;
+  @XmlJavaTypeAdapter(CustomExtensionAdapter.class)
+  @JsonDeserialize(using = DefaultNamespaceDeserializer.class)
+  @JsonSerialize(using = CustomExtensionsSerializer.class)
+  @UserExtensions(extension = "certificationInfo")
+  private Map<String, Object> certificationInfo;
 
   @JsonIgnore @XmlTransient private String expandedJSONLDString;
 
@@ -132,7 +136,7 @@ public class EPCISEvent implements Serializable, OpenEPCISSupport {
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
-      String certificationInfo,
+      Map<String, Object> certificationInfo,
       String expandedJSONLDString,
       OpenEPCISExtension openEPCISExtension) {
     this.type = type;

--- a/epcis/src/main/java/io/openepcis/model/epcis/ObjectEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/ObjectEvent.java
@@ -146,7 +146,7 @@ public class ObjectEvent extends EPCISEvent implements XmlSupportExtension {
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
-      String certificationInfo,
+      Map<String, Object> certificationInfo,
       List<SourceList> sourceList,
       List<DestinationList> destinationList,
       List<SensorElementList> sensorElementList,

--- a/epcis/src/main/java/io/openepcis/model/epcis/TransactionEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/TransactionEvent.java
@@ -126,7 +126,7 @@ public class TransactionEvent extends EPCISEvent implements XmlSupportExtension 
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
-      String certificationInfo,
+      Map<String, Object> certificationInfo,
       List<SourceList> sourceList,
       List<DestinationList> destinationList,
       List<SensorElementList> sensorElementList,

--- a/epcis/src/main/java/io/openepcis/model/epcis/TransformationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/TransformationEvent.java
@@ -161,7 +161,7 @@ public class TransformationEvent extends EPCISEvent implements XmlSupportExtensi
       Map<String, Object> userExtensions,
       Map<String, Object> innerUserExtensions,
       List<Object> contextInfo,
-      String certificationInfo,
+      Map<String, Object> certificationInfo,
       List<SourceList> sourceList,
       List<DestinationList> destinationList,
       List<SensorElementList> sensorElementList,


### PR DESCRIPTION
@sboeckelmann 
As per the discussion, I have converted the certificationInfo field in our openepcis-models to accommodate Object Map<String, Object>. Accordingly, the other classes, tests, examples and hash generator were modified to fix the associated change issues.

Kindly request you to review the changes and approve the PR.