### PR TITLE
EDG-52: fixing the issue with namespaces missing during xml 1.2 to 2.0 conversion

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
@@ -17,6 +17,7 @@ package io.openepcis.model.epcis;
 
 import static com.fasterxml.jackson.annotation.JsonFormat.Feature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE;
 import static com.fasterxml.jackson.annotation.JsonFormat.Feature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS;
+import static io.openepcis.constants.EPCIS.EPCIS_DEFAULT_NAMESPACES;
 
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
@@ -186,6 +187,17 @@ public class EPCISEvent implements Serializable, OpenEPCISSupport {
 
     //Detect default EPCIS namespaces (gs1, cbvmda, etc.) after json deserialization, if present add namespacesURI that are later used for XML marshalling
     DefaultNamespaceDeserializer.getInstance().processExtensions(userExtensions);
+  }
+
+  //Getter method for the @context field to either set to null if only default namespaces are present else return all namespaces
+  public List<Object> getContextInfo() {
+    //Check if the XML-> JSON conversion has custom namespaces apart from default namespaces
+    final Map<String, String> eventNamespaces = DefaultJsonSchemaNamespaceURIResolver.getContext().getEventNamespaces();
+    final boolean hasCustomNamespace = eventNamespaces.values().stream().anyMatch(value -> !EPCIS_DEFAULT_NAMESPACES.containsKey(value));
+
+    // If hasCustomNamespace then return all the namespaces
+    // If does not have additional namespaces then do not include the default namespace in json
+    return hasCustomNamespace ?  contextInfo : null;
   }
 
   public void beforeMarshal(Marshaller m) throws ParserConfigurationException {

--- a/epcis/src/main/java/io/openepcis/model/epcis/modifier/CommonExtensionModifier.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/modifier/CommonExtensionModifier.java
@@ -62,6 +62,9 @@ public class CommonExtensionModifier {
                 //If the element contains the default namespace but contains different prefix then replace with right prefix from EPCIS default namespaces
                 if (!StringUtils.isEmpty(namespaceURI) && PROTECTED_NAMESPACE_OF_CONTEXT.contains(namespaceURI)) {
                     valueElement = replacePrefix(valueElement);
+
+                    //Populate the eventNamespaces with respective URI and Prefix
+                    namespaceResolver.populateEventNamespaces(namespaceURI, valueElement.getPrefix());
                 }
 
                 //If there are many elements then loop over them and add

--- a/epcis/src/main/java/io/openepcis/model/epcis/modifier/CustomContextSerializer.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/modifier/CustomContextSerializer.java
@@ -24,6 +24,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import static io.openepcis.constants.EPCIS.EPCIS_DEFAULT_NAMESPACES;
+
 public class CustomContextSerializer extends JsonSerializer<List<Object>> {
 
   private final DefaultJsonSchemaNamespaceURIResolver namespaceResolver =
@@ -58,9 +60,13 @@ public class CustomContextSerializer extends JsonSerializer<List<Object>> {
         final Map<String, String> modifiedNamespaces = namespaceResolver.getEventNamespaces();
 
         for (final Map.Entry<String, String> entry : modifiedNamespaces.entrySet()) {
-          jsonGenerator.writeStartObject();
-          jsonGenerator.writeStringField(entry.getValue(), entry.getKey());
-          jsonGenerator.writeEndObject();
+
+          //Filter and do not add the Default namespaces such as cbvmda to event @context
+          if (!EPCIS_DEFAULT_NAMESPACES.containsValue(entry.getKey())) {
+            jsonGenerator.writeStartObject();
+            jsonGenerator.writeStringField(entry.getValue(), entry.getKey());
+            jsonGenerator.writeEndObject();
+          }
         }
 
         jsonGenerator.writeEndArray();


### PR DESCRIPTION
@sboeckelmann 

Recently during the conversion of the GS1 Egypt document from XML 1.2 to 2.0 found the following issue:

XML 1.2:

```xml
<extension>
  <ilmd>
    <cbvmda:lotNumber>3UMELQC2B9ZI9GR4332X</cbvmda:lotNumber>
    <cbvmda:itemExpirationDate>2021-03-15</cbvmda:itemExpirationDate>
  </ilmd>
</extension>
```

Converted XML 2.0:

```xml
<ilmd>
  <lotNumber>3UMELQC2B9ZI9GR4332X</lotNumber>
  <itemExpirationDate>2021-03-15</itemExpirationDate>
</ilmd>
```

As we can see from the converted XML 2.0 document the ILMD elements are missing their namespaces/prefix `cbvmda`. Also, the corresponding namespace `xmlns:cbvmda="urn:epcglobal:cbv:mda` is missing in the document.


This PR will fix the above-mentioned issue, also I have verified the associated issues in JSON and have made minor changes to fix them.

Request you to review the PR and approve the same.