### PR TITLE
GEN-315: Migrate to use the new openepcis-digital-link-converter-core instead of old openepcis-epc-digitallink-translator

### DIFF
--- a/epcis/pom.xml
+++ b/epcis/pom.xml
@@ -70,7 +70,7 @@
         </dependency>
         <dependency>
             <groupId>io.openepcis</groupId>
-            <artifactId>openepcis-epc-digitallink-translator</artifactId>
+            <artifactId>openepcis-digital-link-converter-core</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/epcis/src/main/java/io/openepcis/model/epcis/AggregationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/AggregationEvent.java
@@ -16,7 +16,7 @@
 package io.openepcis.model.epcis;
 
 import com.fasterxml.jackson.annotation.*;
-import io.openepcis.epc.translator.util.ConverterUtil;
+import io.openepcis.identifiers.converter.util.ConverterUtil;
 import io.openepcis.model.epcis.extension.OpenEPCISExtension;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;

--- a/epcis/src/main/java/io/openepcis/model/epcis/AssociationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/AssociationEvent.java
@@ -16,7 +16,7 @@
 package io.openepcis.model.epcis;
 
 import com.fasterxml.jackson.annotation.*;
-import io.openepcis.epc.translator.util.ConverterUtil;
+import io.openepcis.identifiers.converter.util.ConverterUtil;
 import io.openepcis.model.epcis.extension.OpenEPCISExtension;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;

--- a/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/EPCISEvent.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.openepcis.epc.translator.util.ConverterUtil;
+import io.openepcis.identifiers.converter.util.ConverterUtil;
 import io.openepcis.model.epcis.extension.OpenEPCISExtension;
 import io.openepcis.model.epcis.extension.OpenEPCISSupport;
 import io.openepcis.model.epcis.modifier.*;

--- a/epcis/src/main/java/io/openepcis/model/epcis/ObjectEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/ObjectEvent.java
@@ -18,7 +18,7 @@ package io.openepcis.model.epcis;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.openepcis.epc.translator.util.ConverterUtil;
+import io.openepcis.identifiers.converter.util.ConverterUtil;
 import io.openepcis.model.epcis.extension.OpenEPCISExtension;
 import io.openepcis.model.epcis.modifier.CustomExtensionAdapter;
 import io.openepcis.model.epcis.modifier.CustomExtensionsSerializer;

--- a/epcis/src/main/java/io/openepcis/model/epcis/TransactionEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/TransactionEvent.java
@@ -16,7 +16,7 @@
 package io.openepcis.model.epcis;
 
 import com.fasterxml.jackson.annotation.*;
-import io.openepcis.epc.translator.util.ConverterUtil;
+import io.openepcis.identifiers.converter.util.ConverterUtil;
 import io.openepcis.model.epcis.extension.OpenEPCISExtension;
 import jakarta.xml.bind.Marshaller;
 import jakarta.xml.bind.Unmarshaller;

--- a/epcis/src/main/java/io/openepcis/model/epcis/TransformationEvent.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/TransformationEvent.java
@@ -18,7 +18,7 @@ package io.openepcis.model.epcis;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import io.openepcis.epc.translator.util.ConverterUtil;
+import io.openepcis.identifiers.converter.util.ConverterUtil;
 import io.openepcis.model.epcis.extension.OpenEPCISExtension;
 import io.openepcis.model.epcis.modifier.CustomExtensionAdapter;
 import io.openepcis.model.epcis.modifier.CustomExtensionsSerializer;

--- a/gs1-web-vocab/pom.xml
+++ b/gs1-web-vocab/pom.xml
@@ -52,7 +52,7 @@
         </dependency>
         <dependency>
             <groupId>io.openepcis</groupId>
-            <artifactId>openepcis-epc-digitallink-translator</artifactId>
+            <artifactId>openepcis-digital-link-converter-core</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
             </dependency>
             <dependency>
                 <groupId>io.openepcis</groupId>
-                <artifactId>openepcis-epc-digitallink-translator</artifactId>
+                <artifactId>openepcis-digital-link-converter-core</artifactId>
                 <version>${project.parent.version}</version>
                 <scope>compile</scope>
             </dependency>

--- a/quarkus/runtime/pom.xml
+++ b/quarkus/runtime/pom.xml
@@ -86,7 +86,7 @@
         </dependency>
         <dependency>
             <groupId>io.openepcis</groupId>
-            <artifactId>openepcis-epc-digitallink-translator</artifactId>
+            <artifactId>openepcis-digital-link-converter-core</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
@sboeckelmann 

As we have recently developed a new application for the `openepcis-digital-link-toolkit-build`, This PR contains the migration from the old `openepcis-epc-digitallink-translator` to the latest `openepcis-digital-link-converter-core`. 

Could you please review the PR and approve the changes?