### PR TITLE
GEN-395: allow jsonld context url in user extension schema.

### DIFF
--- a/epcis/src/main/java/io/openepcis/model/epcis/UserExtensionSchema.java
+++ b/epcis/src/main/java/io/openepcis/model/epcis/UserExtensionSchema.java
@@ -64,4 +64,7 @@ public class UserExtensionSchema {
 
   /** Stores the userID of user updating the schema in UUID format */
   private String updatedBy;
+
+  /** This field holds the Custom URL of the JSON-LD context document associated with the schema. */
+  private String jsonldContextUrl;
 }


### PR DESCRIPTION
@sboeckelmann 

With this PR, we have introduced support for the custom context URL in the user extension schema. Please review and approve the changes.

